### PR TITLE
refact(config): Se integra la variable config

### DIFF
--- a/frontend/config/config.local.js
+++ b/frontend/config/config.local.js
@@ -7,8 +7,8 @@
 
 var Config = {
 	prod : true,
-	port : 4000
+	port : 4000,
+	UNIT_TESTS : {module: 'postulante', controller: 'buscar'}
 };
 
 module.exports = Config;
-module.exports.UNIT_TESTS = {module: 'postulante', controller: 'buscar'};

--- a/frontend/config/config.local.js
+++ b/frontend/config/config.local.js
@@ -8,7 +8,9 @@
 var CONFIG = {
 	prod : true,
 	port : 4000,
-	unit_tests : {module: 'postulante', controller: 'buscar'}
+	tests : {
+		unit: {module: 'postulante', controller: 'buscar'}
+	}
 };
 
 module.exports = CONFIG;

--- a/frontend/config/config.local.js
+++ b/frontend/config/config.local.js
@@ -5,10 +5,10 @@
  * @author Victor Sandoval
  */
 
-var Config = {
+var CONFIG = {
 	prod : true,
 	port : 4000,
-	UNIT_TESTS : {module: 'postulante', controller: 'buscar'}
+	unit_tests : {module: 'postulante', controller: 'buscar'}
 };
 
-module.exports = Config;
+module.exports = CONFIG;

--- a/frontend/config/tasks/gulp_mocha.js
+++ b/frontend/config/tasks/gulp_mocha.js
@@ -16,8 +16,8 @@ function Task(gulp, path, config, plugins, functions) {
         testAll =  all !== null ? all : false;
 
         //Actualizo los valores de las variables acorde a lo solicitado
-        _controller = controller !== null ? controller : config.unit_tests.controller;
-        _module =  module !== null ? module : config.unit_tests.module;
+        _controller = controller !== null ? controller : config.tests.unit.controller;
+        _module =  module !== null ? module : config.tests.unit.module;
         
         //Defino la ubicacion con ayuda de las variables
         ubication = onlyModule ? [_module]: [_module, _controller];

--- a/frontend/config/tasks/gulp_mocha.js
+++ b/frontend/config/tasks/gulp_mocha.js
@@ -16,8 +16,8 @@ function Task(gulp, path, config, plugins, functions) {
         testAll =  all !== null ? all : false;
 
         //Actualizo los valores de las variables acorde a lo solicitado
-        _controller = controller !== null ? controller : config.UNIT_TESTS.controller;
-        _module =  module !== null ? module : config.UNIT_TESTS.module;
+        _controller = controller !== null ? controller : config.unit_tests.controller;
+        _module =  module !== null ? module : config.unit_tests.module;
         
         //Defino la ubicacion con ayuda de las variables
         ubication = onlyModule ? [_module]: [_module, _controller];


### PR DESCRIPTION
La variable config ahora integra la variable UNIT_TESTS
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36342692%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36343675%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36344165%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36345659%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36347178%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36347548%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36348026%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36348185%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36348266%22%2C%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36348356%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20092405588eced0abf6b5180015e277d0d46cfe95%20frontend/config/config.local.js%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36342692%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40carloshs92%2C%20consulta%20%5Cu00bfA%20que%20se%20debe%20que%20haya%20una%20llave%20del%20objeto%20Config%20con%20may%5Cu00fascula%20y%20otras%202%20con%20min%5Cu00fascula%3F%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-05T19%3A19%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2623671%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jansanchez%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40jansanchez%20actualizar%5Cu00e9%20la%20variable%20UNIT_TESTS%20a%20minusculas%20y%20la%20variable%20Config%20se%20cambiar%5Cu00e1%20a%20mayusculas%20con%20el%20fin%20de%20dar%20a%20entender%20que%20es%20una%20constante.%20%22%2C%20%22created_at%22%3A%20%222015-08-05T19%3A27%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1372633%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/carloshs92%22%7D%7D%2C%20%7B%22body%22%3A%20%22Gracias%20carlos%2C%20quedo%20a%20espera%20del%20push.%22%2C%20%22created_at%22%3A%20%222015-08-05T19%3A32%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2623671%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jansanchez%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sugiero%20que%20las%20variables%20dentro%20del%20configsean%20en%20mayusculas%20ya%20que%20son%20variables%20globales%20y%20he%20visto%20en%20otros%20proyectos%20que%20as%5Cu00ed%20lo%20manejan%3A%5Cr%5Cnvar%20Config%20%3D%20%7B%5Cr%5Cn%20%5CtPROD%20%3A%20true%2C%5Cr%5Cn%5CtPORT%20%3A%204000%2C%5Cr%5Cn%5CtUNIT_TESTS%20%3A%20%7Bmodule%3A%20%27postulante%27%2C%20controller%3A%20%27buscar%27%7D%5Cr%5Cn%7D%22%2C%20%22created_at%22%3A%20%222015-08-05T19%3A47%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5455561%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/VictorJSV%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-05T20%3A01%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1372633%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/carloshs92%22%7D%7D%2C%20%7B%22body%22%3A%20%22Dado%20el%20objeto%20%27Config%27%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cnvar%20Config%20%3D%20%7B%5Cr%5Cn%20%20%20%20PROD%20%3A%20true%2C%5Cr%5Cn%20%20%20%20PORT%20%3A%204000%2C%5Cr%5Cn%20%20%20%20UNIT_TESTS%20%3A%20%7Bmodule%3A%20%27postulante%27%2C%20controller%3A%20%27buscar%27%7D%5Cr%5Cn%7D%5Cr%5Cn%5Cr%5Cnmodule.exports%20%3D%20Config%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnEntonces%20las%20opciones%20de%20como%20se%20usar%5Cu00eda%20son%3A%5Cr%5Cn%5Cr%5Cna%29%5Cr%5Cn%60%60%60%5Cr%5Cn_module%20%3D%20config.UNIT_TESTS.module%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cnb%29%5Cr%5Cn%60%60%60%5Cr%5Cn_module%20%3D%20config.UNIT_TEST.MODULE%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cnc%29%5Cr%5Cn%60%60%60%5Cr%5Cn_module%20%3D%20CONFIG.unit_tests.module%3B%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-08-05T20%3A05%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2623671%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jansanchez%22%7D%7D%2C%20%7B%22body%22%3A%20%22hablando%20con%20%40VictorJSV%20acordamos%20que%20seria%20como%20en%20la%20opci%5Cu00f3n%20a.%20Sin%20embargo%20creo%20que%20por%20tema%20est%5Cu00e9tico%20seria%20mejor%20tenerlo%20todo%20como%20min%5Cu00fascula.%22%2C%20%22created_at%22%3A%20%222015-08-05T20%3A10%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1372633%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/carloshs92%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-05T20%3A12%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2623671%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jansanchez%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20frontend/config/config.local.js%3AL7-15%22%7D%2C%20%22Pull%203adeebd4f1715a088c54bd8da828d368b5de5caf%20frontend/config/tasks/gulp_mocha.js%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/frontend-labs/flux/pull/39%23discussion_r36348185%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40VictorJSV%2C%20%40carloshs92.%20Entonces%20por%20un%20tema%20de%20%27uso%27%20quedar%5Cu00eda%20en%20min%5Cu00fasculas%20no%3F.%22%2C%20%22created_at%22%3A%20%222015-08-05T20%3A11%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2623671%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/jansanchez%22%7D%7D%2C%20%7B%22body%22%3A%20%22Esa%20fue%20mi%20propuesta%20y%20%40VictorJSV%20%20me%20comento%20que%20si%20estaba%20bien.%22%2C%20%22created_at%22%3A%20%222015-08-05T20%3A13%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1372633%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/carloshs92%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20frontend/config/tasks/gulp_mocha.js%3AL16-24%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 3adeebd4f1715a088c54bd8da828d368b5de5caf frontend/config/tasks/gulp_mocha.js 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/frontend-labs/flux/pull/39#discussion_r36348185'>File: frontend/config/tasks/gulp_mocha.js:L16-24</a></b>
- <a href='https://github.com/jansanchez'><img border=0 src='https://avatars.githubusercontent.com/u/2623671?v=3' height=16 width=16'></a> @VictorJSV, @carloshs92. Entonces por un tema de 'uso' quedaría en minúsculas no?.
- <a href='https://github.com/carloshs92'><img border=0 src='https://avatars.githubusercontent.com/u/1372633?v=3' height=16 width=16'></a> Esa fue mi propuesta y @VictorJSV  me comento que si estaba bien.
- [x] <a href='#crh-comment-Pull 092405588eced0abf6b5180015e277d0d46cfe95 frontend/config/config.local.js 6'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/frontend-labs/flux/pull/39#discussion_r36342692'>File: frontend/config/config.local.js:L7-15</a></b>
- <a href='https://github.com/jansanchez'><img border=0 src='https://avatars.githubusercontent.com/u/2623671?v=3' height=16 width=16'></a> @carloshs92, consulta ¿A que se debe que haya una llave del objeto Config con mayúscula y otras 2 con minúscula?
- <a href='https://github.com/carloshs92'><img border=0 src='https://avatars.githubusercontent.com/u/1372633?v=3' height=16 width=16'></a> @jansanchez actualizaré la variable UNIT_TESTS a minusculas y la variable Config se cambiará a mayusculas con el fin de dar a entender que es una constante.
- <a href='https://github.com/jansanchez'><img border=0 src='https://avatars.githubusercontent.com/u/2623671?v=3' height=16 width=16'></a> Gracias carlos, quedo a espera del push.
- <a href='https://github.com/VictorJSV'><img border=0 src='https://avatars.githubusercontent.com/u/5455561?v=3' height=16 width=16'></a> Sugiero que las variables dentro del configsean en mayusculas ya que son variables globales y he visto en otros proyectos que así lo manejan:
var Config = {
PROD : true,
PORT : 4000,
UNIT_TESTS : {module: 'postulante', controller: 'buscar'}
}
- <a href='https://github.com/carloshs92'><img border=0 src='https://avatars.githubusercontent.com/u/1372633?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/jansanchez'><img border=0 src='https://avatars.githubusercontent.com/u/2623671?v=3' height=16 width=16'></a> Dado el objeto 'Config':
```
var Config = {
PROD : true,
PORT : 4000,
UNIT_TESTS : {module: 'postulante', controller: 'buscar'}
}
module.exports = Config;
```
Entonces las opciones de como se usaría son:
a)
```
_module = config.UNIT_TESTS.module;
```
b)
```
_module = config.UNIT_TEST.MODULE;
```
c)
```
_module = CONFIG.unit_tests.module;
```
- <a href='https://github.com/carloshs92'><img border=0 src='https://avatars.githubusercontent.com/u/1372633?v=3' height=16 width=16'></a> hablando con @VictorJSV acordamos que seria como en la opción a. Sin embargo creo que por tema estético seria mejor tenerlo todo como minúscula.


<a href='https://www.codereviewhub.com/frontend-labs/flux/pull/39?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/frontend-labs/flux/pull/39?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/frontend-labs/flux/pull/39'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>